### PR TITLE
Improve setup script error handling

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,6 +1,25 @@
 #!/bin/bash
 # Setup script for Website Status Monitor on Debian 12
-set -e
+
+# Exit immediately on error, undefined variable, or pipe failure
+set -euo pipefail
+
+# Display a helpful error message if something fails
+handle_error() {
+    local exit_code=$1
+    local line_no=$2
+    echo "Error: command exited with status ${exit_code} at line ${line_no}." >&2
+    exit "$exit_code"
+}
+trap 'handle_error $? $LINENO' ERR
+
+# Ensure required commands are available
+for cmd in sudo apt-get python3 pip; do
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+        echo "Required command '$cmd' not found. Please install it before running this script." >&2
+        exit 1
+    fi
+done
 
 # Ensure running on Debian/Ubuntu-based system
 sudo apt-get update


### PR DESCRIPTION
## Summary
- Add strict mode and error trap to setup script
- Validate required commands before running setup

## Testing
- `bash -n setup.sh`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892b70d14b483309c55032de31e4c49